### PR TITLE
Fix all crashes caused by any invalid command-line argument.

### DIFF
--- a/source/NoteWindow.cpp
+++ b/source/NoteWindow.cpp
@@ -123,14 +123,13 @@ NoteWindow :: NoteWindow(entry_ref *ref)
 		if (entry.Exists()) {
 			BNode node(&entry);
 			if (node.InitCheck() == B_OK) {
+				char type[B_MIME_TYPE_LENGTH];
 				BNodeInfo nodeInfo(&node);
-				if (nodeInfo.InitCheck() == B_OK) {
-					char type[B_MIME_TYPE_LENGTH];
-					if (nodeInfo.GetType(type) == B_OK &&
-						strcmp(type, "application/takenotes") == 0 &&
-						f.SetTo(ref, B_READ_ONLY) == B_OK)
-						isNoteFile = true;
-				}
+				if (nodeInfo.InitCheck() == B_OK &&
+					nodeInfo.GetType(type) == B_OK &&
+					strcmp(type, "application/takenotes") == 0 &&
+					f.SetTo(ref, B_READ_ONLY) == B_OK)
+					isNoteFile = true;
 			}
 		} else
 			isNewFile = true;

--- a/source/NoteWindow.h
+++ b/source/NoteWindow.h
@@ -130,6 +130,8 @@ class NoteWindow : public BWindow {
 		// Hash table
 		BFile			fDatabase;
 		AppHashTable	*fHash;
+
+		void _CreateNoteView(void);
 };
 
 #endif


### PR DESCRIPTION
Refactored `NoteView` creation.

Now supports any path name as the command-line argument:
- if _path_ is a readable `takenotes` file,
- or if _path_ is a symbolic link to a readable `takenotes` file,
- or if _path_ is a new file and its parent is a concrete directory.

Otherwise, _path_ is ignored, a dialog reports the error, and a new
**Untitled Note** window is opened.

Fixes #33