### PR TITLE
Create a single open file panel and make sure there's only one window per file

### DIFF
--- a/source/NoteApplication.h
+++ b/source/NoteApplication.h
@@ -17,6 +17,7 @@
 #define NOTE_APPLICATION_H
 
 #include "NoteWindow.h"
+#include "NoteRefFilter.h"
 
 #include <Application.h>
 #include <String.h>
@@ -29,22 +30,23 @@ class NoteApplication : public BApplication {
 	public:
 
 							NoteApplication();
+							~NoteApplication();
+
 		virtual void		ArgvReceived(int32 argc, char** argv);
-		virtual void		RefsReceived(BMessage *message);
-		virtual void		MessageReceived(BMessage *message);
+		virtual void		RefsReceived(BMessage* message);
+		virtual void		MessageReceived(BMessage* message);
 		virtual void		ReadyToRun();
 
 				void		_InstallReplicantInDeskbar();
 
-				void 		OpenNote();
-				void		OpenNote(entry_ref *ref);
+				void		OpenNote(entry_ref* ref = NULL);
 				void		CloseNote();
 				status_t	CheckMime();
-
 	private:
 
 		int32		fWindowCount;
-		int32		fWindowCountUntitled;
+		BFilePanel	*fOpenPanel;
+		NoteRefFilter	fNoteRefFilter;
 
 };
 

--- a/source/NoteWindow.h
+++ b/source/NoteWindow.h
@@ -23,7 +23,6 @@
 #include "AlarmWindow.h"
 #include "ChoiceWindow.h"
 #include "TagsWindow.h"
-#include "NoteRefFilter.h"
 
 // Other Libraries
 #include <Window.h>
@@ -55,8 +54,8 @@ struct AlarmData {
 class NoteWindow : public BWindow {
 
 	public:
-								NoteWindow(int32 id);
-								NoteWindow(entry_ref *ref);
+								NoteWindow();
+								NoteWindow(entry_ref* ref);
 								~NoteWindow();
 			virtual void		MessageReceived(BMessage* message);
 			virtual void		Quit();
@@ -68,6 +67,8 @@ class NoteWindow : public BWindow {
 					void 		SetFontStyle (const char* fontFamily, const char *fontStyle);
 					status_t	Save (BMessage*);
 					status_t	_SaveDB(const char* signature);
+
+		entry_ref	*fRef;
 
 	private:
 
@@ -128,12 +129,6 @@ class NoteWindow : public BWindow {
 		// Save panel
 		BFilePanel	*fSavePanel;
 		
-		// Open panel
-		BFilePanel	*fOpenPanel;
-
-		// Ref filter
-		NoteRefFilter	fNoteRefFilter;
-
 		// Hash table
 		BFile			fDatabase;
 		AppHashTable	*fHash;


### PR DESCRIPTION
I moved the open file panel to `NoteApplication` and checked if the file pointed by the `entry_ref` is already opened in one of the windows and in case it is I made it open that specific window in `NoteApplication::OpenNote(entry_ref *ref)`.
I also replaced the variables holding the count of all windows with a `BObjectList` that holds the windows to iterate through them in `NoteApplication::OpenNote(entry_ref *ref)`.

Fixes #37 