### PR TITLE
Now builds

### DIFF
--- a/source/NoteRefFilter.cpp
+++ b/source/NoteRefFilter.cpp
@@ -3,7 +3,7 @@
 
 // System libraries
 #include <NodeInfo.h>
-
+#include <string.h>
 
 // Filter hook method
 bool


### PR DESCRIPTION
Cloned the repo and typed make, but there was a missing include for a strcmp later in the NoteRefFilter.cpp.
Simply added the required include header.
This was on x86_64.