### PR TITLE
Fixed quit crash

### DIFF
--- a/source/NoteWindow.cpp
+++ b/source/NoteWindow.cpp
@@ -1298,6 +1298,7 @@ void NoteWindow :: AboutRequested()
 // Function that quits the window
 void NoteWindow :: Quit(){
 
+	fNoteView->RemoveSelf();
 	note_app->CloseNote();
 	BWindow::Quit();
 


### PR DESCRIPTION
Fixes #36 

Took quite a lot of detective work to get this one down. I was able to trace the issue to BWindow::Quit();.
The issue stems from BScrollView's BScrollBars, which is improperly deallocated due to the TakeNote's special usage of NoteView, indeed, the problematic object is a child of BNoteView.

By calling a RemoveSelf on the NoteView, as advised on this page of the legacy docs: https://www.haiku-os.org/legacy-docs/bebook/BView.html, we prevent the crash and let's the program quit cleanly.

Edit: tested on both x86_64 and x86 (gcc2)